### PR TITLE
Allow for user claim to be defined with json pointer

### DIFF
--- a/path_login.go
+++ b/path_login.go
@@ -309,8 +309,8 @@ func (b *jwtAuthBackend) verifyOIDCToken(ctx context.Context, config *jwtConfig,
 // createIdentity creates an alias and set of groups aliases based on the role
 // definition and received claims.
 func (b *jwtAuthBackend) createIdentity(allClaims map[string]interface{}, role *jwtRole) (*logical.Alias, []*logical.Alias, error) {
-	userClaimRaw, ok := allClaims[role.UserClaim]
-	if !ok {
+	userClaimRaw := getClaim(b.Logger(), allClaims, role.UserClaim)
+	if userClaimRaw == nil {
 		return nil, nil, fmt.Errorf("claim %q not found in token", role.UserClaim)
 	}
 	userName, ok := userClaimRaw.(string)


### PR DESCRIPTION
# Overview
A high level description of the contribution, including:
Who the change affects or is for (stakeholders)?
What is the change? 
Why is the change needed?
How does this change affect the user experience (if at all)?

# Design of Change
How was this change implemented?

# Related Issues/Pull Requests
[ ] [Issue #1234](https://github.com/hashicorp/vault/issues/1234)
[ ] [PR #1234](https://github.com/hashicorp/vault/pr/1234)

# Contributor Checklist
[ ] Add relevant docs to upstream Vault repository, or sufficient reasoning why docs won’t be added yet
[My Docs PR Link](link)
[Example](https://github.com/hashicorp/vault/commit/2715f5cec982aabc7b7a6ae878c547f6f475bba6)
[ ] Add output for any tests not ran in CI to the PR description (eg, acceptance tests)
[ ] Backwards compatible
